### PR TITLE
team page cannot be accessed until wager is placed

### DIFF
--- a/public/css/headers.css
+++ b/public/css/headers.css
@@ -143,3 +143,8 @@ font-size: 1.2rem;
   display: flex;
   align-items: center;
 }
+
+.disabled-link {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const flash = require("express-flash");
 const logger = require("morgan");
 const connectDB = require("./config/database");
 const figlet = require("figlet");
+const Goal = require("./models/Goal")
 
 // ROUTES
 const mainRoutes = require("./routes/main");
@@ -67,6 +68,27 @@ app.use(passport.session());
 
 // use flash messages for errors, info, etc...
 // Make user available in all EJS templates so conditional can be made for header; user || !user for login/logout buttons in nav
+
+app.use(async (req, res,next) => {
+  res.locals.hasWager = false;
+
+  if(!req.user) return next();
+
+  try{
+    const goal = await Goal.findOne({
+      user: req.user.id,
+      completed: flase,
+    }).lean();
+
+    res.locals.hasWager = !!goal?.wagerPaid;
+  }catch (err) {
+    console.error("hasWager middleware error:", err);
+    res.locals.hasWager = false;
+  }
+
+  next();
+});
+
 app.use((req, res, next) => {
   res.locals.user = req.user || null;
   next();

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -71,7 +71,13 @@
                   <!-- show team page on every page but the my group page -->
                    <% if (user && currentpath!== '/teamPage'){ %>
                     <li class="nav-item">
-                    <a href="/teamPage" class="nav-link ">My Group</a>
+                    <a 
+                      href="<%= hasWager ? '/teamPage' : '#' %>" 
+                      class="nav-link <%= !hasWager ? 'disabled-link' : '' %>"
+                      title="<%= !hasWager ? 'Place a wager on your goal to access your group' : '' %>"
+                      >
+                      My Group
+                    </a>
                     </li>
                    <% } %>
                   


### PR DESCRIPTION
Not-allowed cursor was added to the team page in nav if user has not set a wager; team page can still be accessed by manually entering link via localhost3000/teamPage

needs to be updated in backend for page to not be accessible at all until wager is placed