### PR TITLE
Fix userGoal confetti

### DIFF
--- a/views/userGoal.ejs
+++ b/views/userGoal.ejs
@@ -207,15 +207,12 @@
                                         </li>
                                     <% }) %>
                                 </ul>
-
-                                <form action="goal/complete/<%= goals === null ? '' : goals._id %>?_method=PUT" method="POST">
-                                    <button class="btn btn-lg btn-success w-100 fw-bold goal-completed" 
-                                        id="goalCompletedBtn"
-                                        <%= tasks.length > 0 && tasks.every(t => t.task_is_completed) ? '' : 'disabled' %>
-                                        type="<%= goals === null ? "button" : "submit" %>">
-                                     Goal Completed
-                                    </button>
-                                </form>
+                                <button class="btn btn-lg btn-success w-100 fw-bold goal-completed"
+                                    id="goalCompletedBtn"
+                                    <%= tasks.length > 0 && tasks.every(t => t.task_is_completed) ? '' : 'disabled' %>
+                                    type="<%= goals === null ? "button" : "submit" %>">
+                                    Goal Completed
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -284,6 +281,17 @@
             </dialog>
 
         </main>
+        <script async src="https://ga.jspm.io/npm:es-module-shims@1.6.3/dist/es-module-shims.js" crossorigin="anonymous">
+        </script>
+        <script type="importmap">
+            {
+                "imports": {
+                "three": "https://unpkg.com/three@0.159.0/build/three.module.js",
+                "three/addons/": "https://unpkg.com/three@0.159.0/examples/jsm/"
+                }
+            }
+        </script>
+        <script type="module" src="/js/confetti.js"></script>
 
         <!-- Bootstrap JS Bundle -->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
This PR fixes the confetti on the userGoal page (when a goal is completed and the user clicks the goal completed button).

Steps for testing (see video):
- go to /userGoal
- complete all tasks
- click on the Goal Completed button
- see confetti for ~3secs then the page will redirect to the /teamPage

https://github.com/user-attachments/assets/00d1de22-76c6-4031-92c1-8a24be08f6f7

